### PR TITLE
Harmonize local dependency environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This guide explains the required environment variables for working with wrkstrm 
       ```bash
       # Package Steward Configuration
       # Controls whether to use local dependencies (true) or remote dependencies (false)
-      export SPM_CI_USE_LOCAL_DEPS=true
+      export SPM_USE_LOCAL_DEPS=true
       ```
 
 This environment variable controls dependency resolution behavior:
@@ -64,7 +64,7 @@ After adding the variable to your `.zprofile`, verify your setup:
 
 ```bash
 source ~/.zprofile
-echo $SPM_CI_USE_LOCAL_DEPS
+echo $SPM_USE_LOCAL_DEPS
 ```
 
 This should output: `true`
@@ -108,7 +108,7 @@ If the variable isn't being set:
 
 3. Verify the variable after opening a new terminal:
    ```bash
-   echo $SPM_CI_USE_LOCAL_DEPS
+   echo $SPM_USE_LOCAL_DEPS
    ```
 
 ## Setting up zshift


### PR DESCRIPTION
## Summary
- set a single environment variable name for dependency resolution
- replace `SPM_CI_USE_LOCAL_DEPS` with `SPM_USE_LOCAL_DEPS` in `README.md`

## Testing
- `grep -R "SPM_USE_LOCAL_DEPS" -n`
- `grep -R "SPM_CI_USE_LOCAL_DEPS" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_688c45569acc83339aabc85b5be8edf8