### PR TITLE
Fix zshift resource paths

### DIFF
--- a/zshift/Sources/Zshift/ZShift.swift
+++ b/zshift/Sources/Zshift/ZShift.swift
@@ -28,12 +28,20 @@ struct ZShift: AsyncParsableCommand {
   static let themesDir = "~/.oh-my-zsh/themes/"
 
   /// Default directory while Bundle loading is fixed.
-  static let defaultExcludedFile =
-    "~/Code/configs/zshift/Sources/zshift/Resources/excluded_zsh_themes.txt"
+  static let defaultExcludedFile: String = {
+    let fileURL = URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()
+      .appendingPathComponent("Resources/excluded_zsh_themes.txt")
+    return fileURL.path
+  }()
 
   /// Default liked file while Bundle loading is fixed.
-  static let defaultLikedFile =
-    "~/Code/configs/zshift/Sources/zshift/Resources/liked_zsh_themes.txt"
+  static let defaultLikedFile: String = {
+    let fileURL = URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()
+      .appendingPathComponent("Resources/liked_zsh_themes.txt")
+    return fileURL.path
+  }()
 
   /// Load excluded themes from file, falling back to default resource if necessary
   /// NOTE: An fatal error if the file cannot be read.


### PR DESCRIPTION
## Summary
- update default paths to compute from `#file`

## Testing
- `swift build`
- `swift run zshift --version` *(fails: unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_688c45e88bb883339d284bb0ea371c4d