### PR TITLE
Add basic tests for zshift package

### DIFF
--- a/zshift/Package.swift
+++ b/zshift/Package.swift
@@ -20,19 +20,23 @@ let package = Package(
   dependencies: ConfigurationService.inject.dependencies + [
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.0")
   ],
-  targets: [
-    .executableTarget(
-      name: "Zshift",
-      dependencies: [
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "SwiftFigletKit", package: "Figlet"),
-      ],
-      resources: [
-        .process("Resources")  // This will copy all files in the Resources folder),
-      ],
-    )
-  ],
-)
+    targets: [
+      .executableTarget(
+        name: "Zshift",
+        dependencies: [
+          .product(name: "ArgumentParser", package: "swift-argument-parser"),
+          .product(name: "SwiftFigletKit", package: "Figlet"),
+        ],
+        resources: [
+          .process("Resources")  // This will copy all files in the Resources folder),
+        ]
+      ),
+      .testTarget(
+        name: "ZshiftTests",
+        dependencies: ["Zshift"]
+      )
+    ],
+  )
 
 // MARK: - Configuration Service
 

--- a/zshift/Tests/ZshiftTests/ZShiftTests.swift
+++ b/zshift/Tests/ZshiftTests/ZShiftTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Zshift
+
+final class ZShiftTests: XCTestCase {
+  func testExpandTilde() {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    let expanded = ZShift.expandTilde(in: "~/.zshrc")
+    XCTAssertEqual(expanded, "\(home)/.zshrc")
+  }
+
+  func testLoadExcludedThemesFromFile() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("excluded_test.txt")
+    let contents = "themeB\nthemeA\n\nthemeA\n"
+    try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+
+    let themes = ZShift.loadExcludedThemes(from: fileURL.path)
+    XCTAssertEqual(themes, ["themeA", "themeB"])
+  }
+
+  func testAppendThemeToFile() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+    let fileURL = tempDir.appendingPathComponent("append_test.txt")
+    let path = fileURL.path
+
+    if FileManager.default.fileExists(atPath: path) {
+      try FileManager.default.removeItem(atPath: path)
+    }
+
+    try ZShift.append(theme: "first", to: path)
+    try ZShift.append(theme: "second", to: path)
+
+    let result = try String(contentsOfFile: path, encoding: .utf8)
+    XCTAssertEqual(result, "first\nsecond\n")
+  }
+}


### PR DESCRIPTION
## Summary
- add test target to package manifest
- introduce unit tests for path expansion, theme loading, and appending behavior

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688fe4ae1d98833388840eae064ee697