### PR TITLE
Add markdownlint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ This guide explains the required environment variables for working with wrkstrm 
    brew install swift-format
    ```
 
+   Install `markdownlint-cli2` globally with npm for Markdown linting:
+
+   ```bash
+   npm install -g markdownlint-cli2
+   ```
+
 3. **GitHub Local Runner**
 
    Install GitHub's local runner to execute workflows on your machine. For additional configuration options, see [GitHub's self-hosted runner documentation](https://docs.github.com/actions/hosting-your-own-runners/about-self-hosted-runners):
@@ -73,6 +79,9 @@ fastlane --version
 # Check SwiftLint
 swiftlint version
 
+# Check markdownlint
+markdownlint-cli2 --version
+
 # Check GitHub Local Runner (run from the actions-runner directory)
 ./run.sh --version
 ```
@@ -89,6 +98,14 @@ echo $SPM_USE_LOCAL_DEPS
 ```
 
 This should output: `true`
+
+### Run Markdownlint
+
+Use `markdownlint-cli2` with the repository's configuration to lint Markdown files:
+
+```bash
+markdownlint-cli2 --config linting/.markdownlint.jsonc "**/*.md"
+```
 
 ## Troubleshooting
 

--- a/linting/.markdownlint.jsonc
+++ b/linting/.markdownlint.jsonc
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD001": false,                       // heading increment
+  "MD004": { "style": "dash" },         // unordered list marker
+  "MD012": { "maximum": 2 },            // consecutive blank lines
+  "MD013": { "line_length": 100 },
+  "MD024": { "siblings_only": true },   // no duplicate headings at same level
+  "MD033": false,                       // allow inline HTML
+  "MD041": false                        // first line heading not required
+}


### PR DESCRIPTION
## Summary
- add markdownlint config file with tailored rules for headings, list markers, and more

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af271a06d8833390d158c307d68372