### PR TITLE
docs: expand Codex and Clia onboarding for Apple SPM configs

### DIFF
--- a/AGENCY.md
+++ b/AGENCY.md
@@ -1,0 +1,3 @@
+# Agency
+
+_TODO: Record decisions, trade-offs, and ownership for this repository._

--- a/AGENDA.md
+++ b/AGENDA.md
@@ -1,0 +1,3 @@
+# Agenda
+
+_TODO: Outline upcoming goals and review timelines for this repository._

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agents
+
+_TODO: Document the roles and responsibilities for contributors in this repository._

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,3 @@
+# Charter
+
+_TODO: Define the guiding principles and scope for this repository._

--- a/apple/spm/configs/CLI_LOGGING.md
+++ b/apple/spm/configs/CLI_LOGGING.md
@@ -1,0 +1,3 @@
+# CLI Logging
+
+_TODO: Describe how to capture command interactions and outputs automatically._

--- a/apple/spm/configs/FAQ.md
+++ b/apple/spm/configs/FAQ.md
@@ -1,0 +1,3 @@
+# FAQ
+
+_TODO: Collect solutions for common setup and access issues._

--- a/apple/spm/configs/MARKDOWN_LINT.md
+++ b/apple/spm/configs/MARKDOWN_LINT.md
@@ -1,0 +1,3 @@
+# Markdown Linting
+
+_TODO: Outline pre-commit hook configuration for markdown linting._

--- a/apple/spm/configs/MENTORSHIP.md
+++ b/apple/spm/configs/MENTORSHIP.md
@@ -1,0 +1,3 @@
+# Mentorship
+
+_TODO: Explain mentorship pairing for new hires during the first week._

--- a/apple/spm/configs/ONBOARDING_REVIEW.md
+++ b/apple/spm/configs/ONBOARDING_REVIEW.md
@@ -1,0 +1,3 @@
+# Onboarding Review
+
+_TODO: Document quarterly review process for keeping onboarding current._

--- a/apple/spm/configs/PROVISIONING.md
+++ b/apple/spm/configs/PROVISIONING.md
@@ -1,0 +1,3 @@
+# Account Provisioning
+
+_TODO: Provide request and verification checklist for Codex and Clia accounts._

--- a/apple/spm/configs/PR_TEMPLATE.md
+++ b/apple/spm/configs/PR_TEMPLATE.md
@@ -1,0 +1,3 @@
+# Pull Request Template
+
+_TODO: Define PR checklist to confirm account access and CLI usage._

--- a/apple/spm/configs/README.md
+++ b/apple/spm/configs/README.md
@@ -1,0 +1,31 @@
+# Codex + Clia Onboarding
+
+This guide helps new backend engineers and project managers connect to the Codex
+and Clia systems while aligning with repository governance.
+
+## Rationale
+Connecting through documented steps ensures that every interaction can train
+Codex and Clia and preserves a reliable history.
+
+## Getting Started
+1. **Request Access** – obtain Codex and Clia accounts before any work. See
+   [Account Provisioning](PROVISIONING.md).
+2. **Use the CLI** – run all tasks via the official command‑line tools to keep
+   activity traceable.
+3. **Avoid Manual Changes** – refrain from manual edits or UI actions to
+   maintain consistent history.
+
+## Expected Behavior
+- Contributors request Codex and Clia accounts before starting work.
+- All tasks are executed through the CLI; manual edits or UI actions are avoided.
+
+## Workflow Improvements
+Planned enhancements for this onboarding flow are tracked in separate docs:
+- [SETUP.md](SETUP.md) – standardize scripts to bootstrap access and dependencies.
+- [CLI_LOGGING.md](CLI_LOGGING.md) – automate capture of CLI commands and output.
+- [MARKDOWN_LINT.md](MARKDOWN_LINT.md) – add a markdown lint pre‑commit hook.
+- [PR_TEMPLATE.md](PR_TEMPLATE.md) – provide PR templates and checklists.
+- [FAQ.md](FAQ.md) – collect solutions for common setup errors.
+- [ONBOARDING_REVIEW.md](ONBOARDING_REVIEW.md) – outline quarterly review
+  of this guide.
+- [MENTORSHIP.md](MENTORSHIP.md) – pair new hires with a mentor to reinforce the flow.

--- a/apple/spm/configs/SETUP.md
+++ b/apple/spm/configs/SETUP.md
@@ -1,0 +1,3 @@
+# Setup Scripts
+
+_TODO: Document scripts to bootstrap access and dependencies._


### PR DESCRIPTION
## Summary
- expand Apple SPM onboarding with rationale, step-by-step guidance, and expected behavior
- add placeholder governance docs (CHARTER, AGENTS, AGENCY, AGENDA)
- stub documents for setup, provisioning, CLI logging, linting, PR templates, FAQ, review, and mentorship

## Testing
- `swift test` *(fails: type 'SFKFont' has no member 'random')*


------
https://chatgpt.com/codex/tasks/task_e_68b6090cec008333aded2d351c59d9d0